### PR TITLE
add cmd display

### DIFF
--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -196,7 +196,7 @@ public class GatlingMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.remoteArtifactRepositories}")
 	protected List<ArtifactRepository> remoteRepos;
 
-	@Parameter(defaultValue = "false")
+	@Parameter(property = "gatling.displayCmd",defaultValue = "false")
 	private boolean displayCmd;
 
 	/**

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -196,6 +196,9 @@ public class GatlingMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.remoteArtifactRepositories}")
 	protected List<ArtifactRepository> remoteRepos;
 
+	@Parameter(defaultValue = "false")
+	private boolean displayCmd;
+
 	/**
 	 * Executes Gatling simulations.
 	 */
@@ -228,8 +231,8 @@ public class GatlingMojo extends AbstractMojo {
 		JavaMainCaller compilerCaller = new GatlingJavaMainCallerByFork(this, COMPILER_MAIN_CLASS, compilerClasspath, zincJvmArgs, compilerArguments, toolchain, propagateSystemProperties);
 		JavaMainCaller gatlingCaller = new GatlingJavaMainCallerByFork(this, GATLING_MAIN_CLASS, testClasspath, gatlingJvmArgs, gatlingArgs, toolchain, propagateSystemProperties);
 		try {
-			compilerCaller.run(false);
-			gatlingCaller.run(false);
+			compilerCaller.run(displayCmd);
+			gatlingCaller.run(displayCmd);
 		} catch (ExecuteException e) {
 			if (e.getExitValue() == 2)
 				throw new GatlingSimulationAssertionsFailedException(e);


### PR DESCRIPTION
Add a parameter to view the command , because on windows platform sometime we have this kind of error : 
 Cannot run program "C:\Program Files\Java\jdk1.7.0_60\jre\bin\java" (in directory "."): CreateProcess error=206, The filename or extension is too long

With a view on the cmd we should analysis the long cmd