### PR TITLE
Add a verify goal that detects failed simulations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
 		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 		<header.basedir>${project.basedir}</header.basedir>
 		<maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+		<junit.version>5.4.0</junit.version>
 	</properties>
 
 	<dependencyManagement>
@@ -82,6 +84,11 @@
 				<artifactId>plexus-utils</artifactId>
 				<version>${plexus-utils.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${junit.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -105,6 +112,11 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -157,6 +169,10 @@
 							<exclude>make_credentials.py</exclude>
 						</excludes>
 					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/src/main/java/io/gatling/mojo/AssertionsSummary.java
+++ b/src/main/java/io/gatling/mojo/AssertionsSummary.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.FileInputStream;
+
+import static java.lang.Integer.parseInt;
+
+class AssertionsSummary {
+    private final int errors;
+    private final int failures;
+
+    AssertionsSummary(int errors, int failures) {
+        this.errors = errors;
+        this.failures = failures;
+    }
+
+    static AssertionsSummary fromAssertionsFile(File assertionsFile) throws Exception {
+        XPathFactory xpathFactory = XPathFactory.newInstance();
+        XPath xpath = xpathFactory.newXPath();
+
+        try (FileInputStream is = new FileInputStream(assertionsFile)) {
+            Node testsuite = (Node) xpath.evaluate("/testsuite", new InputSource(is), XPathConstants.NODE);
+            String errors = xpath.evaluate("@errors", testsuite);
+            String failures = xpath.evaluate("@failures", testsuite);
+            return new AssertionsSummary(parseInt(errors), parseInt(failures));
+        }
+    }
+
+    int getErrors() {
+        return errors;
+    }
+
+    int getFailures() {
+        return failures;
+    }
+
+    boolean hasFailures() {
+        return errors + failures > 0;
+    }
+}

--- a/src/main/java/io/gatling/mojo/VerifyMojo.java
+++ b/src/main/java/io/gatling/mojo/VerifyMojo.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+/**
+ * Mojo to verify Gatling simulation results.
+ * <p>
+ * Note: For this goal to function property, the results folder may
+ * not contain gatling reports from earlier maven runs.
+ * If your results folder resides inside the target directory
+ * (which is the default), issuing 'mvn clean' will remove all
+ * colliding reports.
+ * </p>
+ */
+@Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY)
+public class VerifyMojo extends AbstractGatlingMojo {
+
+    /**
+     * Use this folder as the folder where results are stored.
+     */
+    @Parameter(property = "gatling.resultsFolder", defaultValue = "${project.build.directory}/gatling")
+    private File resultsFolder;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        File[] runDirectories = resultsFolder.listFiles(File::isDirectory);
+
+        if (runDirectories != null) {
+            for (File runDirectory: runDirectories) {
+                searchForAssertionFailures(runDirectory);
+            }
+        }
+    }
+
+    private void searchForAssertionFailures(File runDirectory) throws MojoExecutionException, MojoFailureException {
+        File jsDir = new File(runDirectory, "js");
+        if (jsDir.exists() && jsDir.isDirectory()) {
+            File assertionFile = new File(jsDir, "assertions.xml");
+            if (assertionFile.exists()) {
+                analyzeFile(assertionFile);
+            }
+        }
+    }
+
+    private void analyzeFile(File assertionFile) throws MojoExecutionException, MojoFailureException {
+        AssertionsSummary summary;
+        try {
+            summary = AssertionsSummary.fromAssertionsFile(assertionFile);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to parse " + assertionFile.toString(), e);
+        }
+        if (summary.hasFailures()) {
+            throw new MojoFailureException("Gatling simulation assertions failed!");
+        }
+    }
+}

--- a/src/test/java/io/gatling/mojo/AssertionsSummaryTest.java
+++ b/src/test/java/io/gatling/mojo/AssertionsSummaryTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AssertionsSummaryTest {
+
+    private AssertionsSummary summary;
+
+    @BeforeEach
+    void parseAssertionsFile() throws Exception {
+        File file = new File("src/test/resources/golden-files/assertions.xml");
+        summary = AssertionsSummary.fromAssertionsFile(file);
+    }
+
+    @Test
+    void errors() {
+        assertEquals(2, summary.getErrors());
+    }
+
+    @Test
+    void failures() {
+        assertEquals(1, summary.getFailures());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0,0,false",
+            "1,0,true",
+            "0,1,true",
+            "1,1,true"
+    })
+    void hasFailures(int errors, int failures, boolean expectedResult) {
+        AssertionsSummary summary = new AssertionsSummary(errors, failures);
+        assertEquals(expectedResult, summary.hasFailures());
+    }
+}

--- a/src/test/resources/golden-files/assertions.xml
+++ b/src/test/resources/golden-files/assertions.xml
@@ -1,0 +1,5 @@
+<testsuite name="computerdatabase.BasicSimulation" tests="3" errors="2" failures="1" time="0">
+<testcase name="Global: count of failed requests is 0.0" status="false" time="0">
+  <failure type="Global">Actual value: 1.0</failure>
+</testcase>
+</testsuite>


### PR DESCRIPTION
This PR addresses https://github.com/gatling/gatling/issues/3379 by adding a new `VerifyMojo` for a _verify_ goal that binds to the _verify_ lifecycle phase. It scans the output folder for _assertions.xml_ files and fails the build if one of them contains errors or failures.

In order to use this feature, `failOnError` has to be set to false so that the _verify_ phase is reached.

The code was inspired by 
https://github.com/gatling/gatling-maven-plugin/blob/3b01b84e52afc102d3fba7928c1f20349487edce/src/main/java/io/gatling/mojo/GatlingMojo.java#L290-L311
and
https://github.com/apache/maven-surefire/blob/a69f10f61f53139f93dc69f19f8df18c6ba9c94c/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java#L76-L97

Example configuration:

```xml
      <plugin>
        <groupId>io.gatling</groupId>
        <artifactId>gatling-maven-plugin</artifactId>
        <version>${gatling-plugin.version}</version>
        <executions>
          <execution>
            <goals>
              <goal>test</goal>
              <goal>verify</goal>
            </goals>
          </execution>
        </executions>
        <configuration>
          <failOnError>false</failOnError>
        </configuration>
      </plugin>
```