### PR TITLE
Make VerifyMojo honor the gatling.skip property

### DIFF
--- a/src/main/java/io/gatling/mojo/AbstractGatlingExecutionMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingExecutionMojo.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+
+public abstract class AbstractGatlingExecutionMojo extends AbstractGatlingMojo {
+
+    static final String LAST_RUN_FILE = "lastRun.txt";
+
+    /**
+     * Use this folder as the folder where results are stored.
+     */
+    @Parameter(property = "gatling.resultsFolder", defaultValue = "${project.build.directory}/gatling")
+    protected File resultsFolder;
+
+    /**
+     * Disable the plugin.
+     */
+    @Parameter(property = "gatling.skip", defaultValue = "false")
+    protected boolean skip;
+}

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -51,9 +51,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 @Mojo(name = "test",
   defaultPhase = LifecyclePhase.INTEGRATION_TEST,
   requiresDependencyResolution = ResolutionScope.TEST)
-public class GatlingMojo extends AbstractGatlingMojo {
-
-  static final String LAST_RUN_FILE = "lastRun.txt";
+public class GatlingMojo extends AbstractGatlingExecutionMojo {
 
   /**
    * A name of a Simulation class to run.
@@ -97,12 +95,6 @@ public class GatlingMojo extends AbstractGatlingMojo {
    */
   @Parameter(property = "gatling.runDescription")
   private String runDescription;
-
-  /**
-   * Disable the plugin.
-   */
-  @Parameter(property = "gatling.skip", defaultValue = "false")
-  private boolean skip;
 
   /**
    * Will cause the project build to look successful, rather than fail, even
@@ -178,12 +170,6 @@ public class GatlingMojo extends AbstractGatlingMojo {
    */
   @Parameter(property = "gatling.resourcesFolder", defaultValue = "${project.basedir}/src/test/resources")
   private File resourcesFolder;
-
-  /**
-   * Use this folder as the folder where results are stored.
-   */
-  @Parameter(property = "gatling.resultsFolder", defaultValue = "${project.build.directory}/gatling")
-  private File resultsFolder;
 
   @Parameter(defaultValue = "${plugin.artifacts}", readonly = true)
   private List<Artifact> artifacts;

--- a/src/main/java/io/gatling/mojo/VerifyMojo.java
+++ b/src/main/java/io/gatling/mojo/VerifyMojo.java
@@ -40,8 +40,22 @@ public class VerifyMojo extends AbstractGatlingMojo {
     @Parameter(property = "gatling.resultsFolder", defaultValue = "${project.build.directory}/gatling")
     private File resultsFolder;
 
+    /**
+     * Disable the plugin.
+     */
+    @Parameter(property = "gatling.skip", defaultValue = "false")
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping gatling-maven-plugin");
+        } else {
+            executePlugin();
+        }
+    }
+
+    private void executePlugin() throws MojoFailureException, MojoExecutionException {
         try {
             verifyLastRun();
         } catch (IOException e) {

--- a/src/main/java/io/gatling/mojo/VerifyMojo.java
+++ b/src/main/java/io/gatling/mojo/VerifyMojo.java
@@ -77,6 +77,8 @@ public class VerifyMojo extends AbstractGatlingExecutionMojo {
             throw new MojoExecutionException("Failed to parse " + assertionFile.toString(), e);
         }
         if (summary.hasFailures()) {
+            getLog().error("Gatling simulation assertions failed.");
+            getLog().error("See the reports in " + resultsFolder.getPath() + " for details.");
             throw new MojoFailureException("Gatling simulation assertions failed!");
         }
     }

--- a/src/main/java/io/gatling/mojo/VerifyMojo.java
+++ b/src/main/java/io/gatling/mojo/VerifyMojo.java
@@ -19,32 +19,17 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static io.gatling.mojo.GatlingMojo.LAST_RUN_FILE;
-
 /**
  * Mojo to verify Gatling simulation results.
  */
 @Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY)
-public class VerifyMojo extends AbstractGatlingMojo {
-
-    /**
-     * Use this folder as the folder where results are stored.
-     */
-    @Parameter(property = "gatling.resultsFolder", defaultValue = "${project.build.directory}/gatling")
-    private File resultsFolder;
-
-    /**
-     * Disable the plugin.
-     */
-    @Parameter(property = "gatling.skip", defaultValue = "false")
-    private boolean skip;
+public class VerifyMojo extends AbstractGatlingExecutionMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {


### PR DESCRIPTION
The `VerifyMojo` does not respect the `gatling.skip` property.
This can lead to unexpected behavior.

To reproduce,

1. Create a simulation with failing assertions.
2. Configure *gatling-maven-plugin* like this

```xml
        <executions>
          <execution>
            <goals>
              <goal>test</goal>
              <goal>verify</goal>
            </goals>
          </execution>
        </executions>
        <configuration>
          <failOnError>false</failOnError>
        </configuration>
```
3. Run `mvn clean verify`.
Verification will fail, which is expected.

4. Run `mvn verify -Dgatling.skip`.
Expected behavior: both Gatling execution and verification are skipped.
Actual behavior: Verification error due to the recorded failures of the previous run.

With this PR, verification will be skipped as expected.

I extracted a new superclass in order to remove duplicated declaration of properties and give `LAST_RUN_FILE` a better home. Let me know if you do not like this.

I also added an log message to `VerifyMojo` in order to increase diagonsability of the maven output. 