### PR TITLE
Add support for setting workingDirectory 

### DIFF
--- a/src/main/java/io/gatling/mojo/Fork.java
+++ b/src/main/java/io/gatling/mojo/Fork.java
@@ -42,9 +42,21 @@ class Fork {
   private final List<String> classpath;
   private final boolean propagateSystemProperties;
   private final Log log;
+  private final File workingDirectory;
 
   private final List<String> jvmArgs = new ArrayList<>();
   private final List<String> args = new ArrayList<>();
+
+  Fork(String mainClassName,//
+       List<String> classpath,//
+       List<String> jvmArgs,//
+       List<String> args,//
+       Toolchain toolchain,//
+       boolean propagateSystemProperties,//
+       Log log) {
+
+    this(mainClassName, classpath, jvmArgs, args, toolchain, propagateSystemProperties, log, null);
+  }
 
   Fork(String mainClassName,//
               List<String> classpath,//
@@ -52,7 +64,8 @@ class Fork {
               List<String> args,//
               Toolchain toolchain,//
               boolean propagateSystemProperties,//
-              Log log) {
+              Log log,
+              File workingDirectory) {
 
     this.mainClassName = mainClassName;
     this.classpath = classpath;
@@ -61,6 +74,7 @@ class Fork {
     this.javaExecutable = safe(toWindowsShortName(findJavaExecutable(toolchain)));
     this.propagateSystemProperties = propagateSystemProperties;
     this.log = log;
+    this.workingDirectory = workingDirectory;
   }
 
   private String toWindowsShortName(String value) {
@@ -123,6 +137,9 @@ class Fork {
     Executor exec = new DefaultExecutor();
     exec.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in));
     exec.setProcessDestroyer(new ShutdownHookProcessDestroyer());
+    if (null != workingDirectory) {
+      exec.setWorkingDirectory(workingDirectory);
+    }
 
     CommandLine cl = new CommandLine(javaExecutable);
     for (String arg : command) {

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -174,6 +174,12 @@ public class GatlingMojo extends AbstractGatlingExecutionMojo {
   @Parameter(defaultValue = "${plugin.artifacts}", readonly = true)
   private List<Artifact> artifacts;
 
+  /**
+   * Specify a different working directory.
+   */
+  @Parameter(property = "gatling.workingDirectory")
+  private File workingDirectory;
+
   private Set<File> existingDirectories;
 
   /**
@@ -267,7 +273,7 @@ public class GatlingMojo extends AbstractGatlingExecutionMojo {
     compilerClasspath.addAll(testClasspath);
     List<String> compilerArguments = compilerArgs();
 
-    Fork forkedCompiler = new Fork(COMPILER_MAIN_CLASS, compilerClasspath, zincJvmArgs, compilerArguments, toolchain, false, getLog());
+    Fork forkedCompiler = new Fork(COMPILER_MAIN_CLASS, compilerClasspath, zincJvmArgs, compilerArguments, toolchain, false, getLog(), workingDirectory);
     try {
       forkedCompiler.run();
     } catch (ExecuteException e) {
@@ -276,7 +282,7 @@ public class GatlingMojo extends AbstractGatlingExecutionMojo {
   }
 
   private void executeGatling(List<String> gatlingJvmArgs, List<String> gatlingArgs, List<String> testClasspath, Toolchain toolchain) throws Exception {
-    Fork forkedGatling = new Fork(GATLING_MAIN_CLASS, testClasspath, gatlingJvmArgs, gatlingArgs, toolchain, propagateSystemProperties, getLog());
+    Fork forkedGatling = new Fork(GATLING_MAIN_CLASS, testClasspath, gatlingJvmArgs, gatlingArgs, toolchain, propagateSystemProperties, getLog(), workingDirectory);
     try {
       forkedGatling.run();
     } catch (ExecuteException e) {


### PR DESCRIPTION
Same idea as e.g. failsafe plugin: http://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#workingDirectory

This improves support for Maven multi-module projects as the plugin can be run within a sub-module underneath some parent.