### PR TITLE
Call rm only if operands exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Build
       run: mvn --no-transfer-progress -B clean verify
     - name: Clean before caching
-      run: find ~/.m2 -name "_remote.repositories" | xargs rm
+      run: find ~/.m2 -name "_remote.repositories" | xargs --no-run-if-empty rm


### PR DESCRIPTION
Motivation:
Github action failed

Modifications:
Use `--no-run-if-empty` option for `xarg`

Result:
Github action succeed