### PR TITLE
Merge Gatling Enterprise packaging, closes MISC-223

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
           maven-${{ runner.os }}-
           maven-
     - name: Build
-      run: mvn --no-transfer-progress -B clean verify
+      run: mvn --no-transfer-progress -B clean spotless:check verify
     - name: Clean before caching
       run: find ~/.m2 -name "_remote.repositories" | xargs --no-run-if-empty rm

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,21 @@
+= Gatling Plugin for Maven
+:toc: macro
+:icons: font
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+image:https://gatling.io/wp-content/uploads/2019/04/logo-gatling-transparent@15x.svg[Gatling^, width="50%, link="https://gatling.io", window="_blank"]
+
+image:https://img.shields.io/github/workflow/status/gatling/gatling-maven-plugin/test-only/master?logo=github&style=for-the-badge[GitHub Workflow Status (master), window="_blank", link="https://github.com/gatling/gatling-maven-plugin/actions?query=branch%3Amaster"]
+image:https://img.shields.io/github/license/gatling/gatling-maven-plugin?logo=apache&style=for-the-badge[GitHub, window="_blank", link="https://opensource.org/licenses/Apache-2.0"]
+image:https://img.shields.io/badge/Google%20Group-Gatling-blue?style=for-the-badge&logo=google[Gatling User Group, window="_blank", link="https://groups.google.com/forum/#!forum/gatling"]
+
+[IMPORTANT]
+
+The documentation now lives on the Gatling website and can be found https://gatling.io/docs/current/extensions/maven_plugin/[here].

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-zip</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.gatling</groupId>
+            <artifactId>gatling-enterprise-plugin-commons</artifactId>
+            <version>0.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>io.gatling</groupId>
     <artifactId>gatling-maven-plugin</artifactId>
-    <version>3.1.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>gatling-maven-plugin</name>
     <description>gatling-maven-plugin</description>
     <packaging>maven-plugin</packaging>
@@ -49,6 +49,7 @@
         <plexus-utils.version>3.1.0</plexus-utils.version>
         <header.basedir>${project.basedir}</header.basedir>
         <junit.version>5.7.2</junit.version>
+        <zt-zip.version>1.14</zt-zip.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -91,6 +92,11 @@
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.zeroturnaround</groupId>
+                <artifactId>zt-zip</artifactId>
+                <version>${zt-zip.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -119,6 +125,10 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-zip</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
+++ b/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
@@ -17,6 +17,7 @@
 package io.gatling.mojo;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -29,7 +30,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class DeprecatedFrontLineMojo extends EnterprisePackageMojo {
 
   @Override
-  public void execute() throws MojoExecutionException {
+  public void execute() throws MojoExecutionException, MojoFailureException {
     getLog()
         .warn(
             "Deprecated configuration. Use 'mvn gatling:enterprisePackage' instead.\n"

--- a/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
+++ b/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
@@ -1,0 +1,39 @@
+
+/*
+ * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Deprecated
+@Mojo(
+    name = "package",
+    defaultPhase = LifecyclePhase.PACKAGE,
+    requiresDependencyResolution = ResolutionScope.TEST)
+public class DeprecatedFrontLineMojo extends EnterprisePackageMojo {
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    getLog()
+        .warn(
+            "Deprecated configuration. Use 'mvn gatling:enterprisePackage' instead.\n"
+                + "See https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/ for more informations.");
+    super.execute();
+  }
+}

--- a/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
@@ -1,0 +1,81 @@
+
+/*
+ * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import io.gatling.plugin.util.EnterpriseClient;
+import io.gatling.plugin.util.EnterpriseClientException;
+import io.gatling.plugin.util.OkHttpEnterpriseClient;
+import java.io.File;
+import java.net.URL;
+import java.util.UUID;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+@Execute(goal = "enterprisePackage")
+@Mojo(name = "enterpriseDeploy", defaultPhase = LifecyclePhase.DEPLOY)
+public class EnterpriseDeployMojo extends AbstractMojo {
+
+  @Parameter(defaultValue = "${project}", readonly = true)
+  private MavenProject project;
+
+  @Parameter(defaultValue = "${project.build.directory}", readonly = true)
+  private File targetPath;
+
+  @Parameter(defaultValue = "shaded")
+  private String shadedClassifier;
+
+  @Parameter(defaultValue = "https://cloud.gatling.io/api/public", readonly = true)
+  private URL enterpriseUrl;
+
+  @Parameter(
+      defaultValue = "${env.GATLING_ENTERPRISE_API_TOKEN}",
+      property = "gatling.enterprise.apiToken",
+      readonly = true)
+  private String apiToken;
+
+  @Parameter(readonly = true)
+  private String packageId;
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+
+    if (apiToken == null) {
+      throw new MojoFailureException(
+          "API token is not configure on plugin, neither available in environment variable");
+    }
+
+    if (packageId == null) {
+      throw new MojoFailureException("Artifact ID is not configure on plugin");
+    }
+
+    final File file = EnterpriseUtil.shadedArtifactFile(project, targetPath, shadedClassifier);
+    final EnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(enterpriseUrl, apiToken);
+
+    try {
+      enterpriseClient.uploadPackage(UUID.fromString(packageId), file);
+      getLog().info("Successfully upload package");
+    } catch (EnterpriseClientException e) {
+      throw new MojoFailureException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
@@ -98,36 +98,14 @@ public class EnterprisePackageMojo extends AbstractMojo {
         .collect(Collectors.toSet());
   }
 
-  private File shadedArtifactFile() {
-    String name =
-        project.getArtifactId() + "-" + project.getVersion() + "-" + shadedClassifier + ".jar";
-    return new File(targetPath.getAbsolutePath(), name);
-  }
-
-  private static final String FRONTLINE_MAVEN_PLUGIN_GROUP_ID = "io.gatling.frontline";
-  private static final String FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID = "frontline-maven-plugin";
-
-  private void deprecatedFrontLineMavenPluginWarning() {
-    final boolean exist =
-        project.getPluginArtifacts().stream()
-            .anyMatch(
-                artifact ->
-                    artifact.getGroupId().equals(FRONTLINE_MAVEN_PLUGIN_GROUP_ID)
-                        && artifact.getArtifactId().equals(FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID));
-    if (exist) {
-      getLog()
-          .warn(
-              FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID
-                  + " is deprecated and should be removed, as this plugin is now self-sufficient");
-    }
-  }
+  private void deprecatedFrontLineMavenPluginWarning() throws MojoFailureException {}
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
 
     Set<Artifact> allDeps = project.getArtifacts();
 
-    deprecatedFrontLineMavenPluginWarning();
+    EnterpriseUtil.failOnLegacyFrontLinePlugin(project);
 
     Artifact gatlingApp = findByGroupIdAndArtifactId(allDeps, GATLING_GROUP_ID, "gatling-app");
     Artifact gatlingChartsHighcharts =

--- a/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
@@ -1,0 +1,309 @@
+
+/*
+ * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.repository.RepositorySystem;
+import org.codehaus.plexus.util.SelectorUtils;
+import org.zeroturnaround.zip.ZipUtil;
+import org.zeroturnaround.zip.commons.FileUtilsV2_2;
+
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
+@Mojo(
+    name = "enterprisePackage",
+    defaultPhase = LifecyclePhase.PACKAGE,
+    requiresDependencyResolution = ResolutionScope.TEST)
+public class EnterprisePackageMojo extends AbstractMojo {
+
+  private static final String[] ALWAYS_EXCLUDES =
+      new String[] {
+        "META-INF/LICENSE",
+        "META-INF/MANIFEST.MF",
+        "META-INF/versions/**",
+        "META-INF/maven/**",
+        "*.SF",
+        "*.DSA",
+        "*.RSA"
+      };
+
+  private static String GATLING_GROUP_ID = "io.gatling";
+  private static String GATLING_HIGHCHARTS_GROUP_ID = "io.gatling.highcharts";
+  private static String GATLING_FRONTLINE_GROUP_ID = "io.gatling.frontline";
+  private static Set<String> GATLING_GROUP_IDS;
+
+  static {
+    HashSet<String> groupIds = new HashSet<>();
+    groupIds.add(GATLING_GROUP_ID);
+    groupIds.add(GATLING_HIGHCHARTS_GROUP_ID);
+    groupIds.add(GATLING_FRONTLINE_GROUP_ID);
+    GATLING_GROUP_IDS = Collections.unmodifiableSet(groupIds);
+  }
+
+  @Component private RepositorySystem repository;
+
+  @Component private MavenProjectHelper projectHelper;
+
+  @Parameter(defaultValue = "${project}", readonly = true)
+  private MavenProject project;
+
+  @Parameter(defaultValue = "${session}", readonly = true)
+  private MavenSession session;
+
+  @Parameter private String[] excludes;
+
+  @Parameter(defaultValue = "shaded")
+  private String shadedClassifier;
+
+  @Parameter(defaultValue = "${project.build.directory}", readonly = true)
+  private File targetPath;
+
+  private Set<Artifact> nonGatlingDependencies(Artifact artifact) {
+    if (artifact == null) {
+      return Collections.emptySet();
+    }
+
+    return resolveTransitively(artifact).stream()
+        .filter(art -> !GATLING_GROUP_IDS.contains(art.getGroupId()))
+        .collect(Collectors.toSet());
+  }
+
+  private File shadedArtifactFile() {
+    String name =
+        project.getArtifactId() + "-" + project.getVersion() + "-" + shadedClassifier + ".jar";
+    return new File(targetPath.getAbsolutePath(), name);
+  }
+
+  private static final String FRONTLINE_MAVEN_PLUGIN_GROUP_ID = "io.gatling.frontline";
+  private static final String FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID = "frontline-maven-plugin";
+
+  private void deprecatedFrontLineMavenPluginWarning() {
+    final boolean exist =
+        project.getPluginArtifacts().stream()
+            .anyMatch(
+                artifact ->
+                    artifact.getGroupId().equals(FRONTLINE_MAVEN_PLUGIN_GROUP_ID)
+                        && artifact.getArtifactId().equals(FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID));
+    if (exist) {
+      getLog()
+          .warn(
+              FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID
+                  + " is deprecated and should be removed, as this plugin is now self-sufficient");
+    }
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+
+    Set<Artifact> allDeps = project.getArtifacts();
+
+    deprecatedFrontLineMavenPluginWarning();
+
+    Artifact gatlingApp = findByGroupIdAndArtifactId(allDeps, GATLING_GROUP_ID, "gatling-app");
+    Artifact gatlingChartsHighcharts =
+        findByGroupIdAndArtifactId(
+            allDeps, GATLING_HIGHCHARTS_GROUP_ID, "gatling-charts-highcharts");
+    Artifact frontlineProbe =
+        findByGroupIdAndArtifactId(allDeps, GATLING_FRONTLINE_GROUP_ID, "frontline-probe");
+
+    if (gatlingApp == null) {
+      throw new MojoExecutionException(
+          "Couldn't find io.gatling:gatling-app in project dependencies");
+    }
+
+    Set<Artifact> gatlingDependencies = new HashSet<>();
+    gatlingDependencies.addAll(nonGatlingDependencies(gatlingApp));
+    gatlingDependencies.addAll(nonGatlingDependencies(gatlingChartsHighcharts));
+    gatlingDependencies.addAll(nonGatlingDependencies(frontlineProbe));
+
+    Set<Artifact> filteredDeps =
+        allDeps.stream()
+            .filter(
+                artifact ->
+                    !GATLING_GROUP_IDS.contains(artifact.getGroupId())
+                        && !(artifact.getGroupId().equals("io.netty")
+                            && artifact.getArtifactId().equals("netty-all"))
+                        && artifactNotIn(artifact, gatlingDependencies))
+            .collect(Collectors.toSet());
+
+    File workingDir;
+    try {
+      workingDir = Files.createTempDirectory("frontline").toFile();
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to create temp dir", e);
+    }
+
+    // extract dep jars
+    for (Artifact artifact : filteredDeps) {
+      ZipUtil.unpack(artifact.getFile(), workingDir, name -> exclude(name) ? null : name);
+    }
+
+    // copy compiled classes
+    File outputDirectory = new File(project.getBuild().getOutputDirectory());
+    Path outputDirectoryPath = outputDirectory.toPath();
+    File testOutputDirectory = new File(project.getBuild().getTestOutputDirectory());
+    Path testOutputDirectoryPath = testOutputDirectory.toPath();
+
+    try {
+      if (outputDirectory.exists()) {
+        FileUtilsV2_2.copyDirectory(
+            outputDirectory,
+            workingDir,
+            pathname -> !exclude(outputDirectoryPath.relativize(pathname.toPath()).toString()),
+            false);
+      }
+      if (testOutputDirectory.exists()) {
+        FileUtilsV2_2.copyDirectory(
+            testOutputDirectory,
+            workingDir,
+            pathname -> !exclude(testOutputDirectoryPath.relativize(pathname.toPath()).toString()),
+            false);
+      }
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to copy compiled classes", e);
+    }
+
+    // generate META-INF directory
+    File metaInfDir = new File(workingDir, "META-INF");
+    metaInfDir.mkdirs();
+
+    // generate maven files directory
+    File mavenDir =
+        new File(
+            new File(new File(metaInfDir, "maven"), project.getGroupId()), project.getArtifactId());
+    mavenDir.mkdirs();
+
+    // generate pom.properties
+    try (FileWriter fw = new FileWriter(new File(mavenDir, "pom.properties"))) {
+      fw.write("groupId=" + project.getGroupId() + "\n");
+      fw.write("artifactId=" + project.getArtifactId() + "\n");
+      fw.write("version=" + project.getVersion() + "\n");
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to generate pom.properties", e);
+    }
+
+    // generate pom.xml
+    try (FileWriter fw = new FileWriter(new File(mavenDir, "pom.xml"))) {
+      fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n");
+      fw.write(
+          "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+              + "\n");
+      fw.write(
+          "    xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+              + "\n");
+      fw.write("    <modelVersion>4.0.0</modelVersion>" + "\n");
+      fw.write("    <groupId>" + project.getGroupId() + "</groupId>" + "\n");
+      fw.write("    <artifactId>" + project.getArtifactId() + "</artifactId>" + "\n");
+      fw.write("    <version>" + project.getVersion() + "</version>" + "\n");
+      fw.write("</project>");
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to generate pom.properties", e);
+    }
+
+    // generate fake manifest
+    File manifest = new File(metaInfDir, "MANIFEST.MF");
+
+    try (FileWriter fw = new FileWriter(manifest)) {
+      fw.write("Manifest-Version: 1.0\n");
+      fw.write("Implementation-Title: " + project.getArtifactId() + "\n");
+      fw.write("Implementation-Version: " + project.getVersion() + "\n");
+      fw.write("Implementation-Vendor: " + project.getGroupId() + "\n");
+      fw.write("Specification-Vendor: GatlingCorp\n");
+      fw.write("Gatling-Version: " + gatlingApp.getVersion() + "\n");
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to generate manifest", e);
+    }
+
+    File shaded = EnterpriseUtil.shadedArtifactFile(project, targetPath, shadedClassifier);
+
+    // generate jar
+    getLog().info("Generating FrontLine shaded jar " + shaded);
+    ZipUtil.pack(workingDir, shaded);
+
+    // attach jar so it can be deployed
+    projectHelper.attachArtifact(project, "jar", shadedClassifier, shaded);
+
+    try {
+      FileUtilsV2_2.deleteDirectory(workingDir);
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to delete working directory " + workingDir, e);
+    }
+  }
+
+  private boolean exclude(String name) {
+    for (String pattern : ALWAYS_EXCLUDES) {
+      if (SelectorUtils.match(pattern, name, false)) {
+        getLog().info("Excluding file " + name);
+        return true;
+      }
+    }
+    if (excludes != null) {
+      for (String pattern : excludes) {
+        if (SelectorUtils.match(pattern, name, false)) {
+          getLog().info("Excluding file " + name);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private Set<Artifact> resolveTransitively(Artifact artifact) {
+    ArtifactResolutionRequest request =
+        new ArtifactResolutionRequest()
+            .setArtifact(artifact)
+            .setResolveRoot(true)
+            .setResolveTransitively(true)
+            .setServers(session.getRequest().getServers())
+            .setMirrors(session.getRequest().getMirrors())
+            .setProxies(session.getRequest().getProxies())
+            .setLocalRepository(session.getLocalRepository())
+            .setRemoteRepositories(session.getCurrentProject().getRemoteArtifactRepositories());
+    return repository.resolve(request).getArtifacts();
+  }
+
+  private static boolean artifactNotIn(Artifact target, Set<Artifact> artifacts) {
+    return findByGroupIdAndArtifactId(artifacts, target.getGroupId(), target.getArtifactId())
+        == null;
+  }
+
+  private static Artifact findByGroupIdAndArtifactId(
+      Set<Artifact> artifacts, String groupId, String artifactId) {
+    for (Artifact artifact : artifacts) {
+      if (artifact.getGroupId().equals(groupId) && artifact.getArtifactId().equals(artifactId)) {
+        return artifact;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/io/gatling/mojo/EnterpriseUtil.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUtil.java
@@ -1,0 +1,30 @@
+
+/*
+ * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import java.io.File;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+
+public class EnterpriseUtil {
+
+  protected static File shadedArtifactFile(
+      MavenProject project, File targetPath, String classifier) {
+    String name = project.getArtifactId() + "-" + project.getVersion() + "-" + classifier + ".jar";
+    return new File(targetPath.getAbsolutePath(), name);
+  }
+}

--- a/src/main/java/io/gatling/mojo/EnterpriseUtil.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUtil.java
@@ -22,6 +22,26 @@ import org.apache.maven.project.MavenProject;
 
 public class EnterpriseUtil {
 
+  private static final String FRONTLINE_MAVEN_PLUGIN_GROUP_ID = "io.gatling.frontline";
+  private static final String FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID = "frontline-maven-plugin";
+
+  protected static void failOnLegacyFrontLinePlugin(MavenProject project)
+      throws MojoFailureException {
+    final boolean exist =
+        project.getPluginArtifacts().stream()
+            .anyMatch(
+                artifact ->
+                    artifact.getGroupId().equals(FRONTLINE_MAVEN_PLUGIN_GROUP_ID)
+                        && artifact.getArtifactId().equals(FRONTLINE_MAVEN_PLUGIN_ARTIFACT_ID));
+    if (exist) {
+      throw new MojoFailureException(
+          "Plugin `frontline-maven-plugin` is no longer needed, its functionality is now included in `gatling-maven-plugin`.\n"
+              + "Please remove `frontline-maven-plugin` from your pom.xml plugins configuration.\n"
+              + "Please use gatling:enterprisePackage instead of configuring it on package phase.\n"
+              + "See https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/ for more information ");
+    }
+  }
+
   protected static File shadedArtifactFile(
       MavenProject project, File targetPath, String classifier) {
     String name = project.getArtifactId() + "-" + project.getVersion() + "-" + classifier + ".jar";

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -45,6 +45,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.ExceptionUtils;
@@ -161,9 +162,15 @@ public class GatlingMojo extends AbstractGatlingExecutionMojo {
 
   private Set<File> existingDirectories;
 
+  @Parameter(defaultValue = "${project}", readonly = true)
+  private MavenProject project;
+
   /** Executes Gatling simulations. */
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+
+    EnterpriseUtil.failOnLegacyFrontLinePlugin(project);
+
     if (skip) {
       getLog().info("Skipping gatling-maven-plugin");
       return;

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,17 @@
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>gatling</role-hint>
+            <implementation>
+                org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+            </implementation>
+            <configuration>
+                <phases>
+                    <integration-test>io.gatling:gatling-maven-plugin:test</integration-test>
+                    <package>io.gatling:gatling-maven-plugin:enterprisePackage</package>
+                </phases>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -10,6 +10,7 @@
                 <phases>
                     <integration-test>io.gatling:gatling-maven-plugin:test</integration-test>
                     <package>io.gatling:gatling-maven-plugin:enterprisePackage</package>
+                    <deploy>io.gatling:gatling-maven-plugin:enterpriseDeploy</deploy>
                 </phases>
             </configuration>
         </component>


### PR DESCRIPTION
### Import Gatling Enterprise packaging goal, closes MISC-223 

**Motivation:**
No need to configure frontline-maven-plugin to package a Jar for gatling
enterprise.

**Modification:**
* Add `gatling:enterprisePackage` goal, packaging shaded Jar
* Support deprecated `package` goal for compatibility
* Add warning when `frontline-maven-plugin` is configured
* Remove `maven-jar-plugin` dependency

**Result:**
Shaded Jar created using either `mvn gatling:enterprisePackage` or
deprecated package phase binding.

---

### Add gatling packaging tyoe

**Motivation:**
Use standard maven phase with gatling maven plugin

**Modification:**
Add gatling component phases configuration

**Result:**
By using gatling packaging:
* `integration-test` binded to `gatling:test`
* `package` binded to `gatling:enterprisePackage`

--- 

### Update README.md to point on documentation