### PR TITLE
chore: sign package with gpg during deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,18 @@ jobs:
           server-id: sonatype-nexus-staging
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Prepare environment
         env:
           SONATYPE_PGP_SECRET: ${{ secrets.SONATYPE_PGP_SECRET }}
         run: |
-          mkdir --parents ~/.sbt/1.0 || true
           echo -n "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --batch --import
 
       - name: Deploy
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_PGP_PASSPHRASE }}
         run: |
           mvn --batch-mode deploy -Dgpg.passphrase="${{ secrets.SONATYPE_PGP_PASSPHRASE }}"

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,26 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
Motivation:
Sonatype OSS requires signature

Modifications:
 * Add gpg plugin into pom.xml
 * configure secret management in github action

Result:
GitHub Action signs the package during the release workflow