### PR TITLE
fix: use SNAPSHOT version when not in tags

### DIFF
--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -3,6 +3,7 @@
                xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
 
   <!-- String, comma separate multiple branches -->
+  <useSnapshot>true</useSnapshot>
   <nonQualifierBranches>main</nonQualifierBranches>
   <mavenLike>false</mavenLike>   <!-- deprecated, use 'strategy' instead -->
 </configuration>


### PR DESCRIPTION
Motivation:
Cannot mvn install twice in a row.
Difficult to test the development

Modifications:
Add a configuration

Result:
better work