### PR TITLE
chore: Update copyright year 2022

### DIFF
--- a/src/etc/header.txt
+++ b/src/etc/header.txt
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/AbstractGatlingExecutionMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingExecutionMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/AssertionsSummary.java
+++ b/src/main/java/io/gatling/mojo/AssertionsSummary.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/CompilationException.java
+++ b/src/main/java/io/gatling/mojo/CompilationException.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
+++ b/src/main/java/io/gatling/mojo/DeprecatedFrontLineMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterprisePackageMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/EnterpriseUtil.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUtil.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/Fork.java
+++ b/src/main/java/io/gatling/mojo/Fork.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,7 +400,7 @@ public class GatlingMojo extends AbstractGatlingExecutionMojo {
 
   private Optional<Class<?>> loadJavaSimulationClass(ClassLoader testClassLoader) {
     try {
-        return Optional.of(testClassLoader.loadClass("io.gatling.javaapi.core.Simulation"));
+      return Optional.of(testClassLoader.loadClass("io.gatling.javaapi.core.Simulation"));
     } catch (ClassNotFoundException e) {
       // ignore
       return Optional.empty();

--- a/src/main/java/io/gatling/mojo/GatlingSimulationAssertionsFailedException.java
+++ b/src/main/java/io/gatling/mojo/GatlingSimulationAssertionsFailedException.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/MainWithArgsInFile.java
+++ b/src/main/java/io/gatling/mojo/MainWithArgsInFile.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/MojoConstants.java
+++ b/src/main/java/io/gatling/mojo/MojoConstants.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/MojoUtils.java
+++ b/src/main/java/io/gatling/mojo/MojoUtils.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/RecorderMojo.java
+++ b/src/main/java/io/gatling/mojo/RecorderMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/gatling/mojo/VerifyMojo.java
+++ b/src/main/java/io/gatling/mojo/VerifyMojo.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/gatling/mojo/AssertionsSummaryTest.java
+++ b/src/test/java/io/gatling/mojo/AssertionsSummaryTest.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/gatling/mojo/VerifyMojoTest.java
+++ b/src/test/java/io/gatling/mojo/VerifyMojoTest.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Alternatively, we could use `2011-$YEAR` and also configure `ratchetFrom` (something like `<ratchetFrom>origin/main</ratchetFrom>`); but that would only update the year on files actually modified (different from what we have in our SBT builds).