### PR TITLE
fix: use SNAPSHOT qualifier only for no tag commit

### DIFF
--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -3,7 +3,6 @@
                xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
 
   <!-- String, comma separate multiple branches -->
-<!--  <useSnapshot>true</useSnapshot>-->
   <nonQualifierBranches>main</nonQualifierBranches>
-  <mavenLike>false</mavenLike>   <!-- deprecated, use 'strategy' instead -->
+  <strategy>MAVEN</strategy>
 </configuration>


### PR DESCRIPTION
Motivation:
Last release was difficult because CI tried to compute the version from the tag
but always append -SNAPSHOT qualifier (because of bad configuration.

Modifications:
 * Remove useSnapshot configuration (that was the mistake)
 * Configure the MAVEN strategy

Result:
jgitver plugin bumps as patch and append SNAPSHOT qualifier when not directly on tag