### PR TITLE
 feat: delegate simulation class discovery to common package MISC-355

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.22.0</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.0.3-M1</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.1.1</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
@@ -16,10 +16,7 @@
  */
 package io.gatling.mojo;
 
-import io.gatling.plugin.EnterprisePlugin;
-import io.gatling.plugin.EnterprisePluginClient;
-import io.gatling.plugin.InteractiveEnterprisePlugin;
-import io.gatling.plugin.InteractiveEnterprisePluginClient;
+import io.gatling.plugin.*;
 import io.gatling.plugin.client.EnterpriseClient;
 import io.gatling.plugin.client.http.OkHttpEnterpriseClient;
 import io.gatling.plugin.exceptions.UnsupportedClientException;
@@ -81,15 +78,13 @@ public abstract class AbstractEnterprisePluginMojo extends AbstractEnterpriseMoj
         }
       };
 
-  protected EnterprisePlugin initEnterprisePlugin() throws MojoFailureException {
-    EnterpriseClient enterpriseClient = initEnterpriseClient();
-    return new EnterprisePluginClient(enterpriseClient, pluginLogger);
+  protected BatchEnterprisePlugin initBatchEnterprisePlugin() throws MojoFailureException {
+    return new BatchEnterprisePluginClient(initEnterpriseClient(), pluginLogger);
   }
 
   protected InteractiveEnterprisePlugin initInteractiveEnterprisePlugin()
       throws MojoFailureException {
-    EnterpriseClient enterpriseClient = initEnterpriseClient();
-    return new InteractiveEnterprisePluginClient(enterpriseClient, pluginIO);
+    return new InteractiveEnterprisePluginClient(initEnterpriseClient(), pluginIO);
   }
 
   private EnterpriseClient initEnterpriseClient() throws MojoFailureException {

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -16,7 +16,7 @@
  */
 package io.gatling.mojo;
 
-import io.gatling.plugin.EnterprisePlugin;
+import io.gatling.plugin.BatchEnterprisePlugin;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import java.io.File;
 import java.util.UUID;
@@ -66,7 +66,7 @@ public class EnterpriseUploadMojo extends AbstractEnterprisePluginMojo {
     }
 
     final File file = shadedArtifactFile();
-    final EnterprisePlugin enterprisePlugin = initEnterprisePlugin();
+    final BatchEnterprisePlugin enterprisePlugin = initBatchEnterprisePlugin();
 
     try {
       if (packageId != null) {


### PR DESCRIPTION
Motivation:
gatling-enterprise-plugin-common now look for simulation classes.

Modifications:
* Delegate simulations discovery to commons library
* Handle introduced exceptions
* Take advantage of common interface between batch and interactive
  enterprise plugin

Result:
If there is no simulation classes, error is returned during plugin execution instead of on cloud.

Ref: MISC-355