### PR TITLE
feat: handle unsupported version exception, closes MISC-373

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.22.2</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.1.1</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.1.2</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -111,7 +111,7 @@ public class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
     }
   }
 
-  private EnterprisePlugin initEnterprisePlugin(Boolean isInteractive) throws MojoFailureException {
+  private EnterprisePlugin initEnterprisePlugin(boolean isInteractive) throws MojoFailureException {
     return isInteractive ? initInteractiveEnterprisePlugin() : initBatchEnterprisePlugin();
   }
 

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -144,7 +144,8 @@ public class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
                       simulationClass,
                       packageIdUuid,
                       simulationSystemProperties,
-                      file));
+                      file),
+              getLog());
     } finally {
       closeSilently(enterprisePlugin);
     }

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -17,7 +17,6 @@
 package io.gatling.mojo;
 
 import io.gatling.plugin.BatchEnterprisePlugin;
-import io.gatling.plugin.exceptions.EnterprisePluginException;
 import java.io.File;
 import java.util.UUID;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -69,14 +68,16 @@ public class EnterpriseUploadMojo extends AbstractEnterprisePluginMojo {
     final BatchEnterprisePlugin enterprisePlugin = initBatchEnterprisePlugin();
 
     try {
-      if (packageId != null) {
-        enterprisePlugin.uploadPackage(UUID.fromString(packageId), file);
-      } else {
-        enterprisePlugin.uploadPackageWithSimulationId(UUID.fromString(simulationId), file);
-      }
+      RecoverEnterprisePluginException.handle(
+          () -> {
+            if (packageId != null) {
+              return enterprisePlugin.uploadPackage(UUID.fromString(packageId), file);
+            } else {
+              return enterprisePlugin.uploadPackageWithSimulationId(
+                  UUID.fromString(simulationId), file);
+            }
+          });
       getLog().info("Package successfully uploaded");
-    } catch (EnterprisePluginException e) {
-      throw new MojoFailureException(e.getMessage(), e);
     } finally {
       closeSilently(enterprisePlugin);
     }

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -76,7 +76,8 @@ public class EnterpriseUploadMojo extends AbstractEnterprisePluginMojo {
               return enterprisePlugin.uploadPackageWithSimulationId(
                   UUID.fromString(simulationId), file);
             }
-          });
+          },
+          getLog());
       getLog().info("Package successfully uploaded");
     } finally {
       closeSilently(enterprisePlugin);

--- a/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
+++ b/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
@@ -21,6 +21,7 @@ import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.Simulation;
 import java.util.stream.Collectors;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
 
 public class RecoverEnterprisePluginException {
 
@@ -29,7 +30,7 @@ public class RecoverEnterprisePluginException {
     R apply() throws EnterprisePluginException;
   }
 
-  static <R> R handle(EnterprisePluginExceptionFunction<R> f) throws MojoFailureException {
+  static <R> R handle(EnterprisePluginExceptionFunction<R> f, Log log) throws MojoFailureException {
     try {
       return f.apply();
     } catch (UnsupportedJavaVersionException e) {
@@ -72,6 +73,9 @@ public class RecoverEnterprisePluginException {
       throw new MojoFailureException(msg);
     } catch (SimulationStartException e) {
       final Simulation simulation = e.getSimulation();
+      if (e.isCreated()) {
+        log.info(CommonLogMessage.simulationCreated(simulation));
+      }
       final String msg =
           "Failed to start simulation.\n"
               + String.format(

--- a/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
+++ b/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
@@ -17,10 +17,7 @@
 package io.gatling.mojo;
 
 import io.gatling.plugin.EmptyChoicesException;
-import io.gatling.plugin.exceptions.EnterprisePluginException;
-import io.gatling.plugin.exceptions.SeveralSimulationClassNamesFoundException;
-import io.gatling.plugin.exceptions.SeveralTeamsFoundException;
-import io.gatling.plugin.exceptions.SimulationStartException;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.Simulation;
 import java.util.stream.Collectors;
 import org.apache.maven.plugin.MojoFailureException;
@@ -35,6 +32,17 @@ public class RecoverEnterprisePluginException {
   static <R> R handle(EnterprisePluginExceptionFunction<R> f) throws MojoFailureException {
     try {
       return f.apply();
+    } catch (UnsupportedJavaVersionException e) {
+      final String msg =
+          e.getMessage()
+              + "\nIn order to target the supported Java bytecode version, please use the following Maven setting:\n"
+              + "<maven.compiler.release>"
+              + e.supportedVersion
+              + "</maven.compiler.release>\n"
+              + "Or, reported class may come from your project dependencies, published targeting Java "
+              + e.version
+              + ".";
+      throw new MojoFailureException(msg);
     } catch (SeveralTeamsFoundException e) {
       final String availableTeams =
           e.getAvailableTeams().stream()

--- a/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
+++ b/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
@@ -1,0 +1,82 @@
+
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import io.gatling.plugin.EmptyChoicesException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.SeveralSimulationClassNamesFoundException;
+import io.gatling.plugin.exceptions.SeveralTeamsFoundException;
+import io.gatling.plugin.exceptions.SimulationStartException;
+import io.gatling.plugin.model.Simulation;
+import java.util.stream.Collectors;
+import org.apache.maven.plugin.MojoFailureException;
+
+public class RecoverEnterprisePluginException {
+
+  @FunctionalInterface
+  public static interface EnterprisePluginExceptionFunction<R> {
+    R apply() throws EnterprisePluginException;
+  }
+
+  static <R> R handle(EnterprisePluginExceptionFunction<R> f) throws MojoFailureException {
+    try {
+      return f.apply();
+    } catch (SeveralTeamsFoundException e) {
+      final String availableTeams =
+          e.getAvailableTeams().stream()
+              .map(t -> String.format("- %s (%s)\n", t.id, t.name))
+              .collect(Collectors.joining());
+      final String teamExample = e.getAvailableTeams().get(0).id.toString();
+      final String msg =
+          "Several teams were found to create a simulation.\n"
+              + "Available teams:\n"
+              + availableTeams
+              + CommonLogMessage.missingConfiguration(
+                  "team", "teamId", "gatling.enterprise.teamId", null, teamExample);
+      throw new MojoFailureException(msg);
+    } catch (SeveralSimulationClassNamesFoundException e) {
+      final String availableClasses =
+          e.getAvailableSimulationClassNames().stream()
+              .map(s -> String.format("- %s\n", s))
+              .collect(Collectors.joining());
+      final String classExample = e.getAvailableSimulationClassNames().stream().findFirst().get();
+      final String msg =
+          "Several simulation classes were found.\n"
+              + "Available classes:\n"
+              + availableClasses
+              + "\n"
+              + CommonLogMessage.missingConfiguration(
+                  "class", "simulationClass", "gatling.simulationClass", null, classExample);
+      throw new MojoFailureException(msg);
+    } catch (SimulationStartException e) {
+      final Simulation simulation = e.getSimulation();
+      final String msg =
+          "Failed to start simulation.\n"
+              + String.format(
+                  "Simulation %s with ID %s exists but could not be started: ",
+                  simulation.name, simulation.id)
+              + e.getCause().getMessage()
+              + "\n"
+              + CommonLogMessage.simulationStartSample(simulation);
+      throw new MojoFailureException(msg, e);
+    } catch (EmptyChoicesException e) {
+      throw new MojoFailureException(e.getMessage(), e);
+    } catch (EnterprisePluginException e) {
+      throw new MojoFailureException("Unhandled enterprise plugin exception", e);
+    }
+  }
+}


### PR DESCRIPTION
chore: centralize plugin exception handling accross tasks
---

**Motivation:**
Recovering from error is always the same

**Modification:**
Add RecoverEnterprisePluginException to extend in order to get recovering method

 
feat: handle unsupported version exception, closes MISC-373
---

**Motivation:**
New commons version throw `UnsupportedJavaVersionException` when java version isn't supported by Gatling Enterprise CLoud

**Modification:**
Log exception message, along java option to target a compatible bytecode.

fix: log simulation creation on enterprise start exception
---

**Motivation:**
On start, exception may occured after simulation creation.

**Modification:**
Log simulation creation if creation flag is true in exception.