### PR TITLE
Pass env variables when starting simulation on gatling cloud, see MISC-368

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.22.6</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.1.2</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.2.0</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Motivation:
- we can send env variables with the new version of commons

Modifications:
- updated  code to new vesion of commons
- send env variables when starting a simulation on gatling cloud
- simulationEnvironmentVariablesString or simulationEnvironmentVariables can be used