### PR TITLE
chore: upgrade gatling-enteprise-plugin-commons to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.22.8</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.2.0</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.3.0</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
@@ -18,7 +18,7 @@ package io.gatling.mojo;
 
 import io.gatling.plugin.*;
 import io.gatling.plugin.client.EnterpriseClient;
-import io.gatling.plugin.client.http.OkHttpEnterpriseClient;
+import io.gatling.plugin.client.http.HttpEnterpriseClient;
 import io.gatling.plugin.exceptions.UnsupportedClientException;
 import io.gatling.plugin.io.JavaPluginScanner;
 import io.gatling.plugin.io.PluginIO;
@@ -109,7 +109,7 @@ public abstract class AbstractEnterprisePluginMojo extends AbstractEnterpriseMoj
 
     try {
       final URL apiUrl = new URL(enterpriseUrl, "api/public");
-      return new OkHttpEnterpriseClient(apiUrl, apiToken, pluginTitle, pluginVersion);
+      return new HttpEnterpriseClient(apiUrl, apiToken, pluginTitle, pluginVersion);
     } catch (UnsupportedClientException e) {
       throw new MojoFailureException(
           "Please update the Gatling Maven plugin to the latest version for compatibility with Gatling Enterprise. See https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/ for more information about this plugin.",

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -155,34 +155,26 @@ public class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
           .runSummary;
     } catch (EnterprisePluginException e) {
       throw new MojoFailureException(e.getMessage(), e);
-    } finally {
-      closeSilently(enterprisePlugin);
     }
   }
 
   private RunSummary createAndStartSimulation(
       EnterprisePlugin enterprisePlugin, File file, UUID teamIdUuid, UUID packageIdUuid)
       throws EnterprisePluginException, MojoFailureException {
-    final SimulationStartResult result;
-    try {
-      result =
-          RecoverEnterprisePluginException.handle(
-              () ->
-                  enterprisePlugin.createAndStartSimulation(
-                      teamIdUuid,
-                      mavenProject.getGroupId(),
-                      mavenProject.getArtifactId(),
-                      simulationClass,
-                      packageIdUuid,
-                      selectProperties(
-                          simulationSystemProperties, simulationSystemPropertiesString),
-                      selectProperties(
-                          simulationEnvironmentVariables, simulationEnvironmentVariablesString),
-                      file),
-              getLog());
-    } finally {
-      closeSilently(enterprisePlugin);
-    }
+    final SimulationStartResult result =
+        RecoverEnterprisePluginException.handle(
+            () ->
+                enterprisePlugin.createAndStartSimulation(
+                    teamIdUuid,
+                    mavenProject.getGroupId(),
+                    mavenProject.getArtifactId(),
+                    simulationClass,
+                    packageIdUuid,
+                    selectProperties(simulationSystemProperties, simulationSystemPropertiesString),
+                    selectProperties(
+                        simulationEnvironmentVariables, simulationEnvironmentVariablesString),
+                    file),
+            getLog());
 
     logSimulationCreatedOrChosen(result);
     return result.runSummary;

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -67,20 +67,13 @@ public class EnterpriseUploadMojo extends AbstractEnterprisePluginMojo {
     final File file = shadedArtifactFile();
     final BatchEnterprisePlugin enterprisePlugin = initBatchEnterprisePlugin();
 
-    try {
-      RecoverEnterprisePluginException.handle(
-          () -> {
-            if (packageId != null) {
-              return enterprisePlugin.uploadPackage(UUID.fromString(packageId), file);
-            } else {
-              return enterprisePlugin.uploadPackageWithSimulationId(
-                  UUID.fromString(simulationId), file);
-            }
-          },
-          getLog());
-      getLog().info("Package successfully uploaded");
-    } finally {
-      closeSilently(enterprisePlugin);
-    }
+    RecoverEnterprisePluginException.handle(
+        () ->
+            packageId != null
+                ? enterprisePlugin.uploadPackage(UUID.fromString(packageId), file)
+                : enterprisePlugin.uploadPackageWithSimulationId(
+                    UUID.fromString(simulationId), file),
+        getLog());
+    getLog().info("Package successfully uploaded");
   }
 }


### PR DESCRIPTION
Motivation:
Remove OkHttpClient where older version contain CVEs

Modifications:
 * upgrade gatling-enteprise-plugin-commons to 1.3.0

Result:
Less dependencies to OkHttp