### PR TITLE
[WIP] chore: move sign plugin configuration into profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
           maven-${{ runner.os }}-
           maven-
     - name: Build
-      run: mvn --no-transfer-progress -B clean spotless:check test
+      run: mvn --no-transfer-progress -B clean verify
     - name: Clean before caching
       run: find ~/.m2 -name "_remote.repositories" | xargs --no-run-if-empty rm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_PGP_PASSPHRASE }}
         run: |
-          mvn --batch-mode deploy -Dgpg.passphrase="${{ secrets.SONATYPE_PGP_PASSPHRASE }}"
+          mvn --batch-mode deploy -Dgpg.passphrase="${{ secrets.SONATYPE_PGP_PASSPHRASE }}" -PRelease

--- a/pom.xml
+++ b/pom.xml
@@ -145,25 +145,6 @@
                     <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
@@ -200,4 +181,33 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>Release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Motivation:
Signature prerequisites are not always available (and should not)
CI (for PR) failed because maven cannot sign without gpg keys (and was right)

Modifications:
 * Move sign plugin configuration into a profile that is only activated in the release GITHUB_JOB (where we provide gpg keys)

Result:
CI pass, developers can call mvn verify, signature gpg keys are only used when required