### PR TITLE
Fix Java location detection, see gatling/gatling#4285

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.23.0</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.4.3</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.4.4</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Motivation:

gatling-maven-plugin and the bundle have to locate the java executable in order to spawn a forked process to run Gatling.
The current strategy is broken:
* it favors the JAVA_HOME env var over the launcher's JVM
* if JAVA_HOME is undefined and Java 8 is used, it will pick the JRE instead of the JDK, causing crashes when compiling Java code

This is the same issue as https://github.com/davidB/scala-maven-plugin/issues/619

Modification:

* Share Java location resolution is commons module.
* Favor current JVM over JAVA_HOME
* Favor JDK over JRE