### PR TITLE
Improve default simulationsFolder for the Recorder

### DIFF
--- a/src/main/java/io/gatling/mojo/RecorderMojo.java
+++ b/src/main/java/io/gatling/mojo/RecorderMojo.java
@@ -55,10 +55,7 @@ public class RecorderMojo extends AbstractGatlingMojo {
   private Integer proxySSLPort;
 
   /** Uses as the folder where generated simulations will be stored. */
-  @Parameter(
-      property = "gatling.recorder.simulationsFolder",
-      alias = "sf",
-      defaultValue = "${project.basedir}/src/test/scala")
+  @Parameter(property = "gatling.recorder.simulationsFolder", alias = "sf")
   private File simulationsFolder;
 
   /** Use this folder as the folder where feeders are stored. */
@@ -89,6 +86,12 @@ public class RecorderMojo extends AbstractGatlingMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    if (simulationsFolder == null) {
+      // project.testCompileSourceRoots typically contains exactly one element (can be set by
+      // build.testSourceDirectory in the POM); but if it is ambiguous we juste take the first one.
+      simulationsFolder = new File(mavenProject.getTestCompileSourceRoots().get(0));
+    }
+
     try {
       List<String> testClasspath = buildTestClasspath();
       List<String> recorderArgs = recorderArgs();


### PR DESCRIPTION
 Motivation:
When running the recorder from the plugin, the simulationsFolder currently always defaults to the standard Java test sources root (even in a project set up for Kotlin or Scala).

Modifications:
Use the first element in project.testCompileSourceRoots as the default simulationsFolder.

Result:
The recorder will default to saving simulations to the folder set with <testSourceDirectory> in the POM, which is typically what the user would expect.