### PR TITLE
Add ability to monitor progress and wait for run end for enterpriseStart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.28.0</spotless-maven-plugin.version>
-        <gatling-enterprise-plugin-commons.version>1.4.12</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.5.0</gatling-enterprise-plugin-commons.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractEnterprisePluginMojo.java
@@ -27,7 +27,6 @@ import io.gatling.plugin.io.PluginScanner;
 import java.net.URL;
 import java.util.Scanner;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractEnterprisePluginMojo extends AbstractEnterpriseMojo {
@@ -48,17 +47,16 @@ public abstract class AbstractEnterprisePluginMojo extends AbstractEnterpriseMoj
       property = "gatling.enterprise.apiToken")
   protected String apiToken;
 
-  private final Log logger = getLog();
   private final PluginLogger pluginLogger =
       new PluginLogger() {
         @Override
         public void info(String message) {
-          logger.info(message);
+          getLog().info(message);
         }
 
         @Override
         public void error(String message) {
-          logger.error(message);
+          getLog().error(message);
         }
       };
 


### PR DESCRIPTION
Usage exemples:
- Default behavior doesn't change: fire and forget, only guarantees that the run was started with the API, we don't wait for any specific status or result.
- We can add `<waitForRunEnd>true</waitForRunEnd>` or run with e.g. `mvn gatling:enterpriseStart -Dgatling.enterprise.waitForRunEnd=true`.