### PR TITLE
feat: get transitive dependencies by group id instead of limiting to artifact id

### DIFF
--- a/src/main/java/io/gatling/mojo/MojoConstants.java
+++ b/src/main/java/io/gatling/mojo/MojoConstants.java
@@ -30,9 +30,7 @@ public final class MojoConstants {
   static final String GATLING_GROUP_ID = "io.gatling";
   static final String GATLING_MODULE_APP = "gatling-app";
   static final String GATLING_HIGHCHARTS_GROUP_ID = "io.gatling.highcharts";
-  static final String GATLING_MODULE_HIGHCHARTS = "gatling-charts-highcharts";
   static final String GATLING_FRONTLINE_GROUP_ID = "io.gatling.frontline";
-  static final String GATLING_FRONTLINE_MODULE_PROBE = "frontline-probe";
   static final Set<String> GATLING_GROUP_IDS;
 
   static {

--- a/src/main/java/io/gatling/mojo/MojoUtils.java
+++ b/src/main/java/io/gatling/mojo/MojoUtils.java
@@ -32,6 +32,7 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 
 public final class MojoUtils {
@@ -128,5 +129,11 @@ public final class MojoUtils {
       }
     }
     return null;
+  }
+
+  static List<Artifact> findByGroupId(Set<Artifact> artifacts, String groupId) {
+    return artifacts.stream()
+        .filter(artifact -> artifact.getGroupId().equals(groupId))
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Motivation:

Instead of having to remove transitive dependencies from new modules by (group id, artifact id) manually (e.g.: Gatling gRPC), it is simpler to get the dependencies of all the submodules of the known group ids instead.