### PR TITLE
feat: switch interactive mode based on maven --batch-mode option or CI env var

### DIFF
--- a/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
@@ -50,6 +50,20 @@ public abstract class AbstractGatlingMojo extends AbstractMojo {
   /** Maven's repository. */
   @Component protected RepositorySystem repository;
 
+  /**
+   * Uses 2 different mechanisms to detect if the plugin is in interactive mode:
+   *
+   * <ul>
+   *   <li>the kind-of standard CI env var on CI tools
+   *   <li>the standard maven option -B,--batch-mode Run in non-interactive (batch), see mvn:help
+   * </ul>
+   *
+   * @return if the plugin is in interactive mode
+   */
+  protected boolean interactive() {
+    return session.getRequest().isInteractiveMode() && !Boolean.parseBoolean(System.getenv("CI"));
+  }
+
   protected List<String> buildTestClasspath() throws Exception {
     List<String> testClasspathElements = new ArrayList<>();
     testClasspathElements.addAll(mavenProject.getTestClasspathElements());

--- a/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
@@ -16,8 +16,6 @@
  */
 package io.gatling.mojo;
 
-import static java.util.Arrays.asList;
-
 import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.util.Fork;
 import io.gatling.plugin.util.ForkMain;
@@ -77,7 +75,7 @@ public abstract class AbstractGatlingMojo extends AbstractMojo {
 
   protected void addArg(List<String> args, String flag, Object value) {
     if (value != null) {
-      args.addAll(asList("-" + flag, value.toString()));
+      args.addAll(List.of("-" + flag, value.toString()));
     }
   }
 

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -23,7 +23,6 @@ import io.gatling.plugin.model.SimulationEndResult;
 import io.gatling.plugin.model.SimulationStartResult;
 import io.gatling.plugin.util.PropertiesParserUtil;
 import java.io.File;
-import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.maven.plugin.MojoFailureException;
@@ -123,7 +122,7 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
     final UUID packageIdUuid = packageId != null ? UUID.fromString(packageId) : null;
     if (simulationSystemProperties == null) {
       // @Parameter(defaultValue = ...) only works for properties with a single value
-      simulationSystemProperties = Collections.emptyMap();
+      simulationSystemProperties = Map.of();
     }
     final File file = enterprisePackage();
 

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -127,7 +127,7 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
     }
     final File file = enterprisePackage();
 
-    final EnterprisePlugin plugin = initEnterprisePlugin(session.getRequest().isInteractiveMode());
+    final EnterprisePlugin plugin = initEnterprisePlugin(interactive());
 
     final SimulationStartResult startResult =
         RecoverEnterprisePluginException.handle(

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -179,9 +179,7 @@ public final class GatlingMojo extends AbstractGatlingExecutionMojo {
 
   private Set<File> runDirectories() {
     File[] directories = resultsFolder.listFiles(File::isDirectory);
-    return (directories == null)
-        ? Collections.emptySet()
-        : new HashSet<>(Arrays.asList(directories));
+    return directories == null ? Set.of() : Set.of(directories);
   }
 
   private void iterateBySimulations(

--- a/src/main/java/io/gatling/mojo/Interactive.java
+++ b/src/main/java/io/gatling/mojo/Interactive.java
@@ -1,0 +1,65 @@
+
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import java.util.List;
+import java.util.Scanner;
+import org.apache.maven.plugin.MojoFailureException;
+
+public class Interactive {
+
+  private static final int MAX_INTERACTIVE_SIMULATION_SELECT_ATTEMPTS = 5;
+
+  static String selectSingleSimulation(List<String> simulations) throws MojoFailureException {
+    return selectSingleSimulationRec(new Scanner(System.in), simulations, 0);
+  }
+
+  private static String selectSingleSimulationRec(
+      Scanner scanner, List<String> simulations, int attempts) throws MojoFailureException {
+    if (attempts > MAX_INTERACTIVE_SIMULATION_SELECT_ATTEMPTS) {
+      throw new MojoFailureException(
+          "Max attempts of reading simulation number ("
+              + MAX_INTERACTIVE_SIMULATION_SELECT_ATTEMPTS
+              + ") reached. Aborting.");
+    } else {
+      System.out.println("Choose a simulation number:");
+      for (int i = 0; i < simulations.size(); i++) {
+        System.out.println("     [" + i + "] " + simulations.get(i));
+      }
+
+      try {
+        int selected = Integer.parseInt(scanner.nextLine());
+        if (selected < 0 || selected >= simulations.size()) {
+          System.out.println("Invalid selection. Please try again.");
+          return selectSingleSimulationRec(scanner, simulations, attempts + 1);
+        }
+
+        return simulations.get(selected);
+
+      } catch (NumberFormatException e) {
+        System.out.println("Invalid number. Please try again.");
+        return selectSingleSimulationRec(scanner, simulations, attempts + 1);
+      }
+    }
+  }
+
+  static String selectRunDescription() {
+    System.out.println("Enter a run description (optional)");
+    String trimmed = new Scanner(System.in).nextLine().trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/src/main/java/io/gatling/mojo/MojoUtils.java
+++ b/src/main/java/io/gatling/mojo/MojoUtils.java
@@ -60,7 +60,7 @@ public final class MojoUtils {
   }
 
   public static <T> List<T> arrayAsListEmptyIfNull(T[] array) {
-    return array == null ? Collections.emptyList() : Arrays.asList(array);
+    return array == null ? List.of() : Arrays.asList(array);
   }
 
   /**


### PR DESCRIPTION
Motivation:

The interactive mode of the old bundle was very helpful.
We should replicate it in the maven plugin now that it's replacing the old bundle.

Modification:

Unless maven batch mode is enable or the CI env var is set to true, switch to interactive mode and let the user select the simulation class and the run description.

Interactive mode will be completely dropped from core Gatling.