### PR TITLE
chore: upgrade to 1.9.0-M17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven-plugin-annotations.version>3.6.2</maven-plugin-annotations.version>
         <header.basedir>${project.basedir}</header.basedir>
         <junit.version>5.10.2</junit.version>
-        <gatling-enterprise-plugin-commons.version>1.9.0-M14</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.9.0-M17</gatling-enterprise-plugin-commons.version>
 
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-plugin-plugin.version>3.12.0</maven-plugin-plugin.version>

--- a/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/AbstractGatlingMojo.java
@@ -17,6 +17,7 @@
 package io.gatling.mojo;
 
 import io.gatling.plugin.io.PluginLogger;
+import io.gatling.plugin.model.BuildTool;
 import io.gatling.plugin.util.Fork;
 import io.gatling.plugin.util.ForkMain;
 import io.gatling.plugin.util.JavaLocator;
@@ -48,18 +49,19 @@ public abstract class AbstractGatlingMojo extends AbstractMojo {
   /** Maven's repository. */
   @Component protected RepositorySystem repository;
 
-  /**
-   * Uses 2 different mechanisms to detect if the plugin is in interactive mode:
-   *
-   * <ul>
-   *   <li>the kind-of standard CI env var on CI tools
-   *   <li>the standard maven option -B,--batch-mode Run in non-interactive (batch), see mvn:help
-   * </ul>
-   *
-   * @return if the plugin is in interactive mode
-   */
-  protected boolean interactive() {
-    return session.getRequest().isInteractiveMode() && !Boolean.parseBoolean(System.getenv("CI"));
+  protected BuildTool buildTool = BuildTool.MAVEN;
+
+  protected String pluginVersion() {
+    final String pluginVersion = getClass().getPackage().getImplementationVersion();
+    if (pluginVersion == null) {
+      // Should not happen if the plugin is built and packaged properly
+      throw new IllegalStateException("Gatling plugin title and version not found");
+    }
+    return pluginVersion;
+  }
+
+  protected Boolean requireBatchMode() {
+    return !session.getRequest().isInteractiveMode();
   }
 
   protected List<String> buildTestClasspath() throws Exception {

--- a/src/main/java/io/gatling/mojo/CommonLogMessage.java
+++ b/src/main/java/io/gatling/mojo/CommonLogMessage.java
@@ -23,7 +23,9 @@ public final class CommonLogMessage {
   private CommonLogMessage() {}
 
   public static String simulationStartSuccess(URL enterpriseUrl, String reportsPath) {
-    return "Simulation successfully started; reports are available at " + enterpriseUrl + reportsPath;
+    return "Simulation successfully started; reports are available at "
+        + enterpriseUrl
+        + reportsPath;
   }
 
   /**

--- a/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
@@ -19,7 +19,6 @@ package io.gatling.mojo;
 import io.gatling.plugin.BatchEnterprisePlugin;
 import io.gatling.plugin.deployment.DeploymentConfiguration;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
-import io.gatling.plugin.model.BuildTool;
 import io.gatling.plugin.model.DeploymentInfo;
 import java.io.File;
 import org.apache.maven.plugin.MojoFailureException;
@@ -45,9 +44,7 @@ public final class EnterpriseDeployMojo extends AbstractEnterprisePluginMojo {
               deploymentFile,
               packageFile,
               mavenProject.getArtifactId(),
-              isPrivateRepositoryEnabled,
-              BuildTool.MAVEN,
-              getClass().getPackage().getImplementationVersion());
+              isPrivateRepositoryEnabled);
 
       getPluginContext().put(CONTEXT_ENTERPRISE_DEPLOY_INFO, deploymentInfo);
     } catch (EnterprisePluginException e) {

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -59,7 +59,7 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
     final Map context = getPluginContext();
     final DeploymentInfo deploymentInfo =
         (DeploymentInfo) context.get(EnterpriseDeployMojo.CONTEXT_ENTERPRISE_DEPLOY_INFO);
-    final EnterprisePlugin plugin = initEnterprisePlugin(interactive());
+    final EnterprisePlugin plugin = initEnterprisePlugin(requireBatchMode());
 
     try {
       RunSummary runSummary = plugin.startSimulation(simulationName, deploymentInfo);
@@ -69,10 +69,6 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
       throw new MojoFailureException(
           "Unhandled Gatling Enterprise plugin exception: " + e.getMessage(), e);
     }
-  }
-
-  private EnterprisePlugin initEnterprisePlugin(boolean isInteractive) throws MojoFailureException {
-    return isInteractive ? initInteractiveEnterprisePlugin() : initBatchEnterprisePlugin();
   }
 
   private void waitForRunEnd(EnterprisePlugin plugin, RunSummary startedRun)

--- a/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -22,6 +22,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import io.gatling.plugin.GatlingConstants;
 import io.gatling.plugin.SimulationSelector;
+import io.gatling.plugin.model.BuildPlugin;
 import io.gatling.plugin.util.Fork;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -354,7 +355,7 @@ public final class GatlingMojo extends AbstractGatlingExecutionMojo {
             includes,
             excludes,
             runMultipleSimulations,
-            interactive());
+            BuildPlugin.getInstance(buildTool, pluginVersion(), requireBatchMode()).interactive);
 
     SimulationSelector.Result.Error error = result.error;
 

--- a/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
+++ b/src/main/java/io/gatling/mojo/RecoverEnterprisePluginException.java
@@ -16,7 +16,6 @@
  */
 package io.gatling.mojo;
 
-import io.gatling.plugin.EmptyChoicesException;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.exceptions.UnsupportedJavaVersionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -46,8 +45,6 @@ public final class RecoverEnterprisePluginException {
               + e.supportedVersion
               + " or lower.";
       throw new MojoFailureException(msg);
-    } catch (EmptyChoicesException e) {
-      throw new MojoFailureException(e.getMessage(), e);
     } catch (EnterprisePluginException e) {
       throw new MojoFailureException(
           "Unhandled Gatling Enterprise plugin exception: " + e.getMessage(), e);

--- a/src/main/java/io/gatling/mojo/UnsupportedClientMojoException.java
+++ b/src/main/java/io/gatling/mojo/UnsupportedClientMojoException.java
@@ -1,0 +1,28 @@
+
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.mojo;
+
+import io.gatling.plugin.exceptions.UnsupportedClientException;
+import org.apache.maven.plugin.MojoFailureException;
+
+public class UnsupportedClientMojoException extends MojoFailureException {
+  public UnsupportedClientMojoException(UnsupportedClientException e) {
+    super(
+        "Please update the Gatling Maven plugin to the latest version for compatibility with Gatling Enterprise. See https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/ for more information about this plugin.",
+        e);
+  }
+}


### PR DESCRIPTION
Do not merge until @tpetillot release an M16 milestone :)

Motivation:
Interactive & CI envvar detection should be shared in common plugin library.

Modifications:
- Upgraded to 1.9.0-M16
- Deleted interactive() method
- Pull-up buildTool field, requireBatchMode, pluginConfiguration.

Result:
Less logic in maven plugin, more in common !