### PR TITLE
feat: set run title and description with enterpriseStart, closes HYB-592

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven-plugin-annotations.version>3.6.2</maven-plugin-annotations.version>
         <header.basedir>${project.basedir}</header.basedir>
         <junit.version>5.10.2</junit.version>
-        <gatling-enterprise-plugin-commons.version>1.9.0-M17</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.9.0</gatling-enterprise-plugin-commons.version>
 
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-plugin-plugin.version>3.12.0</maven-plugin-plugin.version>

--- a/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseStartMojo.java
@@ -19,6 +19,7 @@ package io.gatling.mojo;
 import io.gatling.plugin.EnterprisePlugin;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.model.DeploymentInfo;
+import io.gatling.plugin.model.RunComment;
 import io.gatling.plugin.model.RunSummary;
 import io.gatling.plugin.model.SimulationEndResult;
 import java.util.Map;
@@ -47,6 +48,12 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
   @Parameter(property = "gatling.enterprise.simulationName")
   private String simulationName;
 
+  @Parameter(property = "gatling.enterprise.runTitle")
+  private String runTitle;
+
+  @Parameter(property = "gatling.enterprise.runDescription")
+  private String runDescription;
+
   /**
    * Wait for the result after starting the simulation on Gatling Enterprise, and complete with an
    * error if the simulation ends with any error status.
@@ -62,7 +69,9 @@ public final class EnterpriseStartMojo extends AbstractEnterprisePluginMojo {
     final EnterprisePlugin plugin = initEnterprisePlugin(requireBatchMode());
 
     try {
-      RunSummary runSummary = plugin.startSimulation(simulationName, deploymentInfo);
+      final RunComment runComment = new RunComment(runTitle, runDescription);
+      final RunSummary runSummary =
+          plugin.startSimulation(simulationName, deploymentInfo, runComment);
       getLog().info(CommonLogMessage.simulationStartSuccess(enterpriseUrl, runSummary.reportsPath));
       waitForRunEnd(plugin, runSummary);
     } catch (EnterprisePluginException e) {


### PR DESCRIPTION
Motivation:
- Users want to identify their simulation runs conditions
- Users should be able to set run title and description to add metadata

Modifications:
- Pass run title and description as start operation parameters

Result:
- Run title and description can be set by users at simulation start