### PR TITLE
chore: handle simulation validation ID on deploy command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <header.basedir>${project.basedir}</header.basedir>
         <junit.version>5.12.2</junit.version>
-        <gatling-enterprise-plugin-commons.version>1.16.3</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.17.1</gatling-enterprise-plugin-commons.version>
         <gatling-shared-cli.version>0.0.6</gatling-shared-cli.version>
 
         <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>

--- a/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseDeployMojo.java
@@ -33,6 +33,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public final class EnterpriseDeployMojo extends AbstractEnterprisePluginMojo {
   public static final String CONTEXT_ENTERPRISE_DEPLOY_INFO = "enterprise_deploy_info";
 
+  @Parameter(property = ConfigurationConstants.DeployOptions.ValidateSimulationId.SYS_PROP)
+  private String validateSimulationId;
+
   @Parameter(property = ConfigurationConstants.DeployOptions.PackageDescriptorFilename.SYS_PROP)
   private String customPackageFilename;
 
@@ -44,11 +47,18 @@ public final class EnterpriseDeployMojo extends AbstractEnterprisePluginMojo {
     final BatchEnterprisePlugin plugin = initBatchEnterprisePlugin();
     try {
       DeploymentInfo deploymentInfo =
-          plugin.deployFromDescriptor(
-              deploymentFile,
-              packageFile,
-              mavenProject.getArtifactId(),
-              isPrivateRepositoryEnabled);
+          (validateSimulationId == null)
+              ? plugin.deployFromDescriptor(
+                  deploymentFile,
+                  packageFile,
+                  mavenProject.getArtifactId(),
+                  isPrivateRepositoryEnabled)
+              : plugin.deployFromDescriptor(
+                  deploymentFile,
+                  packageFile,
+                  mavenProject.getArtifactId(),
+                  isPrivateRepositoryEnabled,
+                  validateSimulationId);
 
       getPluginContext().put(CONTEXT_ENTERPRISE_DEPLOY_INFO, deploymentInfo);
     } catch (EnterprisePluginException e) {

--- a/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
+++ b/src/main/java/io/gatling/mojo/EnterpriseUploadMojo.java
@@ -16,70 +16,17 @@
  */
 package io.gatling.mojo;
 
-import io.gatling.plugin.BatchEnterprisePlugin;
-import io.gatling.plugin.ConfigurationConstants;
-import java.io.File;
-import java.util.UUID;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * Mojo to package Gatling simulations and immediately upload them to Gatling Enterprise Cloud. The
- * package must already be configured on Gatling Enterprise (see <a
- * href="https://docs.gatling.io/reference/execute/cloud/user/package-conf/">the reference
- * documentation</a>).
- */
 @Execute(goal = "enterprisePackage")
 @Mojo(name = "enterpriseUpload")
 public final class EnterpriseUploadMojo extends AbstractEnterprisePluginMojo {
-
-  /**
-   * The ID of the package configured on Gatling Enterprise where you want to upload your Gatling
-   * simulations (see <a
-   * href="https://docs.gatling.io/reference/execute/cloud/user/package-conf/">the reference
-   * documentation</a>).
-   */
-  @Parameter(property = ConfigurationConstants.UploadOptions.PackageId.SYS_PROP)
-  private String packageId;
-
-  /**
-   * Only used if 'packageId' is NOT defined. The ID of a simulation configured on Gatling
-   * Enterprise; your Gatling simulations will be uploaded to the package configured for that
-   * simulation (see <a
-   * href="https://docs.gatling.io/reference/execute/cloud/user/simulations/#step-1-general">the
-   * reference documentation</a>).
-   */
-  @Parameter(property = ConfigurationConstants.UploadOptions.SimulationId.SYS_PROP)
-  private String simulationId;
-
   @Override
   public void execute() throws MojoFailureException {
-    if (packageId == null && simulationId == null) {
-      final String msg =
-          "Missing packageID\n"
-              + "You must configure the ID of an existing package in Gatling Enterprise; see https://docs.gatling.io/reference/execute/cloud/user/package-conf/ \n"
-              + CommonLogMessage.missingConfiguration(
-                  "package ID",
-                  "packageId",
-                  ConfigurationConstants.UploadOptions.PackageId.SYS_PROP,
-                  null,
-                  "MY_PACKAGE_ID")
-              + "Alternately, if you don't configure a packageId, you can configure the simulationId of an existing simulation on Gatling Enterprise: your code will be uploaded to the package used by that simulation.";
-      throw new MojoFailureException(msg);
-    }
-
-    final File file = enterprisePackage();
-    final BatchEnterprisePlugin enterprisePlugin = initBatchEnterprisePlugin();
-
-    RecoverEnterprisePluginException.handle(
-        () ->
-            packageId != null
-                ? enterprisePlugin.uploadPackage(UUID.fromString(packageId), file)
-                : enterprisePlugin.uploadPackageWithSimulationId(
-                    UUID.fromString(simulationId), file),
-        getLog());
-    getLog().info("Package successfully uploaded");
+    throw new MojoFailureException(
+        "The enterprise upload command is no longer supported. It has been replaced by the enterprise deploy command."
+            + " Refer to the documentation for more information: https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise");
   }
 }


### PR DESCRIPTION
[chore: drop enterprise upload command with expressive message](https://github.com/gatling/gatling-maven-plugin/commit/976721d8f245ad38bffb6d276587d6be46d515e7)

**Motivation:**
Command is replaced by enterprise deploy.

**Modification:**
Drop command support, when command is called an error message redirect to deploy command documentation.

[chore: handle simulation validation ID on deploy command](https://github.com/gatling/gatling-maven-plugin/commit/83739626bc163d67c39233bfdf59ad6f81ff1934)

**Motivation:**
Validate a given simulation ID have been deployed.