### PR TITLE
fix: revert update gatling-enterprise-common-plugin to 1.20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <header.basedir>${project.basedir}</header.basedir>
         <junit.version>5.13.4</junit.version>
-        <gatling-enterprise-plugin-commons.version>1.20.3</gatling-enterprise-plugin-commons.version>
+        <gatling-enterprise-plugin-commons.version>1.20.2</gatling-enterprise-plugin-commons.version>
         <gatling-shared-cli.version>0.0.7</gatling-shared-cli.version>
 
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>


### PR DESCRIPTION
Motivation:
The incriminated commit break SH compatibility

Modification:
This reverts commit b4691c96dad6991ee30de1efcaaad283b5a2a2f2.

Result:
Rollback dependency, restore self-hosted compatibility